### PR TITLE
skip device permissions for other platforms

### DIFF
--- a/src/permissions.js
+++ b/src/permissions.js
@@ -1,4 +1,5 @@
 const {systemPreferences} = require("electron")
+const { platform } = require('node:process')
 
 /**
  * Gets the media permissions this app has set.
@@ -9,6 +10,9 @@ const {systemPreferences} = require("electron")
  * @returns {{camera: String, microphone: String, screen: String}}
  */
 const getMediaPermissions = () => {
+  if (platform !== 'win32' || platform !== 'darwin')
+    return {camera: "granted", microphone: "granted", screen: "granted"}
+  
   const types = ["camera", "microphone", "screen"]
   const perms = {}
   for (const type of types) {


### PR DESCRIPTION
since `systemPreferences.getMediaAccessStatus` is only on Windows and MacOs, then permissions are granted by default for other system platforms.