### PR TITLE
cancel pull request #1 and fix its typo

### DIFF
--- a/src/permissions.js
+++ b/src/permissions.js
@@ -10,8 +10,9 @@ const { platform } = require('node:process')
  * @returns {{camera: String, microphone: String, screen: String}}
  */
 const getMediaPermissions = () => {
-  if (platform !== 'win32' && platform !== 'darwin')
+  if (platform !== 'win32' && platform !== 'darwin'){
     return {camera: "granted", microphone: "granted", screen: "granted"}
+  }
   
   const types = ["camera", "microphone", "screen"]
   const perms = {}


### PR DESCRIPTION
see #1 for context
instead of:
```js
if (platform !== 'win32' || platform !== 'darwin')
```
now it's:

```js
if (platform !== 'win32' && platform !== 'darwin')
```
notice the `||` changed into `&&`