### PR TITLE
Fix #5

### DIFF
--- a/src/windows.js
+++ b/src/windows.js
@@ -15,6 +15,7 @@ const {storeValues, getStoreValue} = require("./common/store")
 const {actions} = require("./common/actions")
 const {hasAllMediaPermissions} = require("./permissions")
 const {isLoggedIn} = require("./login")
+const { platform } = require("node:process")
 
 const webPreferences = {
   sandbox: false,
@@ -230,6 +231,10 @@ const getCameraWindow = () => {
  * @param display{Object} the currently active display
  */
 const initializeControlWindow = (display) => {
+  let offset = 10
+  if( platform === 'win32' ){
+    offset = 60
+  }
   controlWindow = new BrowserWindow({
     frame: false,
     transparent: true,
@@ -243,7 +248,7 @@ const initializeControlWindow = (display) => {
     backgroundColor: "#00000000",
     x: 120,
     //y: display.bounds.height / 2 - 300,
-    y: display.workAreaSize.height - 60,
+    y: display.workAreaSize.height - offset,
     width: 220,
     height: 50,
     webPreferences: webPreferences,


### PR DESCRIPTION
fixes #5 
changed `display.bounds` to `display.workAreaSize`.
Also changed the value of `y` offset coordinate of the control window from `10` to `60`.
worked fine on my side on windows, macos and linux.